### PR TITLE
feat: add a new endpoint to get credential defenition id

### DIFF
--- a/src/metadata/metadata.controller.ts
+++ b/src/metadata/metadata.controller.ts
@@ -1,10 +1,21 @@
-import { Controller, Put, Body, Param, Res, HttpStatus } from '@nestjs/common';
+import {
+  Controller,
+  Put,
+  Body,
+  Param,
+  Res,
+  HttpStatus,
+  Get,
+} from '@nestjs/common';
 import { MetadataService } from './metadata.service';
 import { Response } from 'express';
-
+import { ConfigService } from '@nestjs/config';
 @Controller('metadata')
 export class MetadataController {
-  constructor(private readonly metadataService: MetadataService) {}
+  constructor(
+    private readonly metadataService: MetadataService,
+    private readonly configService: ConfigService,
+  ) {}
 
   @Put(':connId')
   async updateMetadata(
@@ -23,5 +34,20 @@ export class MetadataController {
         .status(HttpStatus.INTERNAL_SERVER_ERROR)
         .send('Failed to update metadata');
     }
+  }
+
+  @Get('/transcript-credential-definition-id')
+  getId(@Res() response: Response): Response {
+    const transcriptCredentialDefinitionId = this.configService.get<string>(
+      'TRANSCRIPT_CREDENTIAL_DEFINITION_ID',
+    );
+    if (!transcriptCredentialDefinitionId) {
+      return response.status(HttpStatus.NOT_FOUND).json({
+        message: 'Transcript Credential Definition ID not found',
+      });
+    }
+    return response.status(HttpStatus.OK).json({
+      transcriptCredentialDefinitionId,
+    });
   }
 }


### PR DESCRIPTION
# Pull Request
## Description

This pull request introduces a new endpoint in the metadata service. The purpose of this endpoint is to send the credential definition ID to the front-end side.

## JIRA Ticket(s)
N/A

## Type of Change

Please check the corresponding type:
- [ ] Bug fix
- [ ] Chore
- [ ] Documentation
- [x] Feature
- [ ] Hotfix
- [ ] Infrastructure
- [ ] Refactor
- [ ] Test
- [ ] Version bump
- [ ] Other (please add a comment below explaining the type of change)

## Screenshots & Evidence

<img width="1233" alt="Screenshot 2024-05-31 at 6 43 43 PM" src="https://github.com/DigiCred-Holdings/cape-fear-aca-py-controller/assets/32930151/5855b577-0c86-4e19-a0f6-3dc8a5b1226b">



<img width="1236" alt="Screenshot 2024-05-31 at 6 43 48 PM" src="https://github.com/DigiCred-Holdings/cape-fear-aca-py-controller/assets/32930151/3a03a95c-276b-4b8f-8af6-a1ad47d088b9">




